### PR TITLE
Revert "Further fix, replacing .scoped with .all."

### DIFF
--- a/lib/rails_admin/extensions/pundit/authorization_adapter.rb
+++ b/lib/rails_admin/extensions/pundit/authorization_adapter.rb
@@ -47,9 +47,9 @@ module RailsAdmin
         # to those which the user can perform the given action on.
         def query(action, abstract_model)
           begin
-            @controller.policy_scope(abstract_model.model.all)
+            @controller.policy_scope(abstract_model.model)
           rescue ::Pundit::NotDefinedError
-            abstract_model.model.all
+            abstract_model.model
           end
         end
 


### PR DESCRIPTION
This reverts commit 2f3e70c32f819382b87b9495d87aec6a607779a5, which causes
a big slowdown in the dashboard when there are tables with hundreds of
thousands of rows.