### PR TITLE
fix: query method should always return an ActiveRecord::Relation

### DIFF
--- a/lib/rails_admin/extensions/pundit/authorization_adapter.rb
+++ b/lib/rails_admin/extensions/pundit/authorization_adapter.rb
@@ -50,7 +50,7 @@ module RailsAdmin
           begin
             @controller.policy_scope(abstract_model.model)
           rescue ::Pundit::NotDefinedError
-            abstract_model.model
+            abstract_model.model.all
           end
         end
 


### PR DESCRIPTION
As the comment of the `query` method says it should always return a scope, even in case of exception