### PR TITLE
added the _pundit_authorization_performed variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@
 
 [RailsAdmin](https://github.com/sferik/rails_admin) integration with [Pundit](https://github.com/elabs/pundit) authorization system
 
+## Note
+
+This is a fork of [Sudosu's gem](https://github.com/sudosu/rails_admin_pundit), which does not include support for Pundit's method ```after_action verify_authorized``` method. This resulted in automatic Pundit::AuthorizationNotPerformedError with Rails Admin. This fork fixes the issue
+
 ## Installation
 
 Add this line to your application's Gemfile:
 
-    gem "rails_admin_pundit", :github => "sudosu/rails_admin_pundit"
+    gem "rails_admin_pundit", :github => "Samy-Amar/rails_admin_pundit"
 
 And then execute:
 

--- a/lib/rails_admin/extensions/pundit/authorization_adapter.rb
+++ b/lib/rails_admin/extensions/pundit/authorization_adapter.rb
@@ -28,6 +28,7 @@ module RailsAdmin
         # instance if it is available.
         def authorize(action, abstract_model = nil, model_object = nil)
           @controller.instance_variable_set(:@_policy_authorized, true)
+          @controller.instance_variable_set(:@_pundit_policy_authorized, true)
           record = model_object || abstract_model && abstract_model.model
           unless policy(record).rails_admin?(action)
             raise ::Pundit::NotAuthorizedError, "not allowed to #{action} this #{record}"


### PR DESCRIPTION
The _authorization_performed variable does not work with my version of Pundit (1.1.0). Pundit calls the variable _pundit_authorization_performed. The code now works for me. 