### PR TITLE
Fix scope bug

### DIFF
--- a/lib/rails_admin/extensions/pundit/authorization_adapter.rb
+++ b/lib/rails_admin/extensions/pundit/authorization_adapter.rb
@@ -47,11 +47,9 @@ module RailsAdmin
         # and bulk_delete/destroy actions and should return a scope which limits the records
         # to those which the user can perform the given action on.
         def query(action, abstract_model)
-          begin
-            @controller.policy_scope(abstract_model.model.all)
-          rescue ::Pundit::NotDefinedError
-            abstract_model.model.all
-          end
+          @controller.policy_scope(abstract_model.model.all)
+        rescue ::Pundit::NotDefinedError
+          abstract_model.model.all
         end
 
         # This is called in the new/create actions to determine the initial attributes for new

--- a/lib/rails_admin/extensions/pundit/authorization_adapter.rb
+++ b/lib/rails_admin/extensions/pundit/authorization_adapter.rb
@@ -48,7 +48,7 @@ module RailsAdmin
         # to those which the user can perform the given action on.
         def query(action, abstract_model)
           begin
-            @controller.policy_scope(abstract_model.model)
+            @controller.policy_scope(abstract_model.model.all)
           rescue ::Pundit::NotDefinedError
             abstract_model.model.all
           end


### PR DESCRIPTION
avoid exception `(Model) is not an ActiveRecord::Relation` for model which scope is defined.